### PR TITLE
fix: #4 custom sort import preserving comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       {
         "title": "Run Custom Import Sort",
         "command": "customImportSort.sortImports"
+      },
+      {
+        "title": "Run Custom Import Sort Preserving Comments",
+        "command": "customImportSort.sortImportsPreservingComments"
       }
     ],
     "configuration": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-import-sort",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Alex Rudoy",
   "publisher": "AlexRudoy",
   "displayName": "Custom Import Sort",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { sortImports } from "./utils/sortImports";
+import { sortImportsPreservingComments } from "./utils/sortImportsPreservingComments";
 
 export function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand("customImportSort.sortImports", () => {
@@ -13,6 +14,35 @@ export function activate(context: vscode.ExtensionContext) {
         if (/^[jt]sx?$/.test(extension)) {
           const text = document.getText();
           const sortedText = sortImports(text);
+          if (text !== sortedText) {
+            editor.edit((editBuilder) => {
+              editBuilder.replace(
+                new vscode.Range(
+                  new vscode.Position(0, 0),
+                  new vscode.Position(document.lineCount, 0)
+                ),
+                sortedText
+              );
+            });
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        vscode.window.showErrorMessage(error.message);
+      }
+    }
+  });
+  vscode.commands.registerCommand("customImportSort.sortImportsPreservingComments", () => {
+    try {
+      const editor = vscode.window.activeTextEditor;
+      if (editor) {
+        const document = editor.document;
+        const fileName = document.fileName;
+        const extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+        if (/^[jt]sx?$/.test(extension)) {
+          const text = document.getText();
+          const sortedText = sortImportsPreservingComments(text);
           if (text !== sortedText) {
             editor.edit((editBuilder) => {
               editBuilder.replace(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
         .getConfiguration("customImportSort")
         .get("sortOnSave");
       if (sortOnSave) {
-        vscode.commands.executeCommand("customImportSort.sortImports");
+        vscode.commands.executeCommand("customImportSort.sortImportsPreservingComments");
       }
     })
   );

--- a/src/utils/sortImportsPreservingComments.ts
+++ b/src/utils/sortImportsPreservingComments.ts
@@ -1,0 +1,17 @@
+
+import { TConfig, TConfigWithId, TImportData } from "../types";
+import { getAndValidateConfig } from "./getAndValidateConfig";
+import { groupLines } from "./groupLines";
+import { joinMapToFlatArray } from "./joinMapToFlatArray";
+import { splitImportsAndNonImportsPreservingComments } from "./splitImportsAndNonImportsPreservingComments";
+
+export const sortImportsPreservingComments = (text: string) => {
+  const configArray = getAndValidateConfig();
+  const lines = text.split("\n");
+  const { importLines, nonImportLines } = splitImportsAndNonImportsPreservingComments(lines);
+  const linesMap = groupLines(importLines, configArray);
+  const sortedImportLines = joinMapToFlatArray(linesMap, configArray);
+  return [...sortedImportLines, ...nonImportLines]
+    .filter((line, index, array) => line !== "" || line !== array[index + 1])
+    .join("\n");
+};

--- a/src/utils/splitImportsAndNonImportsPreservingComments.ts
+++ b/src/utils/splitImportsAndNonImportsPreservingComments.ts
@@ -1,0 +1,33 @@
+import { TImportData } from "../types";
+
+export const splitImportsAndNonImportsPreservingComments = (
+  lines: string[]
+): { importLines: TImportData[]; nonImportLines: string[] } => {
+  const importLines: TImportData[] = [];
+  const nonImportLines: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith("import")) {
+      let path = lines[i].split(/["']/)[1];
+      importLines.push({
+        line: `${lines[i]}`,
+        path,
+      });
+      
+      // handle multi-line imports
+      while (!path) {
+        i++;
+        path = lines[i].split(/["']/)[1];
+        importLines[importLines.length - 1].line += `\n${lines[i]}`;
+        importLines[importLines.length - 1].path = path;
+      }
+    } else {
+      nonImportLines.push(lines[i]);
+    }
+  }
+  return {
+    importLines,
+    nonImportLines: [
+      ...nonImportLines,
+    ],
+  };
+};


### PR DESCRIPTION
Hello @Alex-Rudoy 

I tried to fix the issue I have opened here 
- #4 

It turns out I was able to create a command that is actually doing what I asked to.
In fact this PR actually fixes a problem of not preserving comments in their original location.

I think this should be the default behaviour, but please guide me on how you think is better, also i don't want to introudce any breaking change  on the ux point of view. Just let me know what do you think about it

I have tested it by using this file
```js
import c from "c";
import a from "a";
import z from "z";

/**
 * 1
*/
const x = "t";

/**
 * 2
*/
const x2 = "t";

/**
 * 3
*/
const x4 = "t";
```

for which the expected results is just having the imports sorted out
```js
import a from "a";
import c from "c";
import z from "z";

/**
 * 1
*/
const x = "t";

/**
 * 2
*/
const x2 = "t";

/**
 * 3
*/
const x4 = "t";
```


Anyway this is my first time I contribute on a vs code extension project, so please guide me on some needed refactor or better testing
I'm a bit excited lol