### PR TITLE
Added "Ignore File" Option

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ export function activate(context: vscode.ExtensionContext) {
         const extension = fileName.substring(fileName.lastIndexOf('.') + 1);
         if (/^[jt]sx?$/.test(extension)) {
           const text = document.getText();
+          if(text.includes('/* customImportSort:ignore */')) return;
+
           const sortedText = sortImports(text);
           if (text !== sortedText) {
             editor.edit((editBuilder) => {


### PR DESCRIPTION
If you don't want the imports of a file to be sorted, a feature has been added where you can add the line below to make sure that the file is not modified:

`/* customImportSort:ignore */`